### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/TWIDisplay/keywords.txt
+++ b/TWIDisplay/keywords.txt
@@ -8,8 +8,8 @@ setScrollMode	KEYWORD2
 setSegmentData	KEYWORD2
 setDot	KEYWORD2
 setDots	KEYWORD2
-setApostrophe KEYWORD2
-setApostrophes KEYWORD2
+setApostrophe	KEYWORD2
+setApostrophes	KEYWORD2
 setPosition	KEYWORD2
 writeInt	KEYWORD2
 writeChar	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords